### PR TITLE
Remove visibility check to enable pub on underlying

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ strong-type = "0.10"
 
 ## Examples
 #### Creating a named strong type:
+With a private field:
 ```rust
 use strong_type::StrongType;
 
@@ -51,6 +52,17 @@ struct Tag(String);
 
 let tag = Tag::new("dev");
 const TAG: Tag = Tag::const_new("prod");
+```
+
+With a public field:
+```rust
+use strong_type::StrongType;
+
+#[derive(StrongType)]
+struct Timestamp(pub i64);
+
+let timestamp = Timestamp(1701620628123456789);
+println!("{}", timestamp); // Timestamp(1701620628123456789)
 ```
 
 #### Demonstrating type distinctiveness:

--- a/strong-type-derive/src/detail/mod.rs
+++ b/strong-type-derive/src/detail/mod.rs
@@ -33,4 +33,4 @@ pub(crate) use hash::implement_hash;
 pub(crate) use nan::implement_nan;
 pub(crate) use negate::implement_negate;
 pub(crate) use underlying_type_utils::{get_type, TypeInfo, UnderlyingType, ValueTypeGroup};
-pub(crate) use utils::{get_attributes, is_struct_valid, StrongTypeAttributes};
+pub(crate) use utils::{get_attributes, validate_struct, StrongTypeAttributes};

--- a/strong-type-derive/src/detail/utils.rs
+++ b/strong-type-derive/src/detail/utils.rs
@@ -1,6 +1,6 @@
 use crate::detail::underlying_type_utils::get_type_group;
 use crate::detail::{get_type, TypeInfo, UnderlyingType};
-use syn::{Data, DeriveInput, Fields, Visibility};
+use syn::{Data, DeriveInput, Fields};
 
 pub(crate) struct StrongTypeAttributes {
     pub has_auto_operators: bool,
@@ -51,15 +51,13 @@ pub(crate) fn get_attributes(input: &DeriveInput) -> StrongTypeAttributes {
     attributes
 }
 
-pub(crate) fn is_struct_valid(input: &DeriveInput) -> bool {
+pub(crate) fn validate_struct(input: &DeriveInput) {
     if let Data::Struct(data_struct) = &input.data {
         if let Fields::Unnamed(fields_unnamed) = &data_struct.fields {
-            return (fields_unnamed.unnamed.len() == 1)
-                && matches!(
-                    fields_unnamed.unnamed.first().unwrap().vis,
-                    Visibility::Inherited
-                );
+            if fields_unnamed.unnamed.len() == 1 {
+                return;
+            }
         }
-    }
-    false
+    };
+    panic!("Strong type must be a tuple struct with exactly one field.");
 }

--- a/strong-type-derive/src/strong_type.rs
+++ b/strong-type-derive/src/strong_type.rs
@@ -5,7 +5,7 @@ use crate::detail::{
     implement_infinity, implement_limit, implement_nan, implement_negate,
     implement_primitive_accessor, implement_primitive_accessor_derived,
     implement_primitive_str_accessor, implement_primitive_str_accessor_derived,
-    implement_str_conversion, is_struct_valid, StrongTypeAttributes, TypeInfo, UnderlyingType,
+    implement_str_conversion, validate_struct, StrongTypeAttributes, TypeInfo, UnderlyingType,
     ValueTypeGroup,
 };
 use proc_macro2::TokenStream;
@@ -13,9 +13,7 @@ use quote::quote;
 use syn::DeriveInput;
 
 pub(super) fn expand_strong_type(input: DeriveInput) -> TokenStream {
-    if !is_struct_valid(&input) {
-        panic!("Strong type must be a tuple struct with one private field.");
-    }
+    validate_struct(&input);
 
     let name = &input.ident;
     let StrongTypeAttributes {

--- a/strong-type-tests/tests/strong_type.rs
+++ b/strong-type-tests/tests/strong_type.rs
@@ -8,7 +8,7 @@ mod tests {
     fn test_type<T: std::fmt::Debug + Clone + Send + Sync + Default + PartialEq>() {}
 
     #[test]
-    fn test_basic() {
+    fn test_basic_with_new() {
         #[derive(StrongType)]
         struct NamedI8(i8);
         test_type::<NamedI8>();
@@ -265,12 +265,31 @@ mod tests {
     }
 
     #[test]
-    fn test_const() {
+    fn test_const_new() {
         #[derive(StrongType)]
         struct NamedI32(i32);
 
         const NAMED_I32: NamedI32 = NamedI32::const_new(1);
 
         assert_eq!(NAMED_I32, NamedI32::new(1));
+    }
+
+    #[test]
+    fn test_pub_type() {
+        #[derive(StrongType)]
+        #[strong_type(auto_operators)]
+        pub struct NamedI32(pub i32);
+        let mut x = NamedI32(1);
+        x.0 += 2;
+        assert_eq!(x, NamedI32::new(1) + NamedI32::new(2));
+        assert_eq!(x.to_string(), "NamedI32(3)");
+
+        #[derive(StrongType)]
+        pub struct NamedString(pub String);
+        let mut s = NamedString("Tim".to_string());
+        s.0.push_str("er");
+
+        assert_eq!(s, NamedString::new("Timer"));
+        assert_eq!(s.to_string(), "NamedString(Timer)");
     }
 }


### PR DESCRIPTION
#65 

This enables construction like
```
#[derive(StrongType)]
struct Timestamp(pub i64);

let timestamp = Timestamp(1701620628123456789);
println!("{}", timestamp); // Timestamp(1701620628123456789)
```